### PR TITLE
Export the exact function and not the entire module for each

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-const combinePsbts = require('./psbts');
-const createPsbt = require('./psbts');
-const decodePsbt = require('./psbts');
-const encodePsbt = require('./psbts');
-const extractTransaction = require('./psbts');
-const finalizePsbt = require('./psbts');
-const signPsbt = require('./psbts');
-const updatePsbt = require('./psbts');
+const { combinePsbts } = require('./psbts');
+const { createPsbt } = require('./psbts');
+const { decodePsbt } = require('./psbts');
+const { encodePsbt } = require('./psbts');
+const { extractTransaction } = require('./psbts');
+const { finalizePsbt } = require('./psbts');
+const { signPsbt } = require('./psbts');
+const { updatePsbt } = require('./psbts');
 
 module.exports = {
   combinePsbts,


### PR DESCRIPTION
 [Here](https://github.com/alexbosworth/psbt/blob/master/index.js#L1)

I see that you export for each function the entire module and not the single function, for example the `combinePsbt` should be something like `const {combinePsbt} = require...`

In this way if I use it installing it as a module I don't need to do anymone:

```javascript
psbt.combinePsbt.combinePsbt(args)
```

but just 

```javascript
psbt.combinePsbt(args)
```